### PR TITLE
Fix XSS vulnerability in selectize's `create_option`

### DIFF
--- a/vendor/assets/javascripts/simple_form_extension/selectize.coffee
+++ b/vendor/assets/javascripts/simple_form_extension/selectize.coffee
@@ -66,11 +66,11 @@ class Selectize
         </div>
       """
 
-    option_create: (data) =>
+    option_create: (data, escape) =>
       """
         <div class="create" data-selectable="">
           #{ @$el.data('add-translation') }
-          <strong>#{ data.input }</strong> ...
+          <strong>#{ escape(data.input) }</strong> ...
         </div>
       """
 


### PR DESCRIPTION
Because the input was passed directly to the dom, it allowed for XSS.